### PR TITLE
Fix sliding health bar

### DIFF
--- a/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
+++ b/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
@@ -330,7 +330,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 7164038243177157252}
   m_HandleRect: {fileID: 0}


### PR DESCRIPTION
Fixed the health bar being interactable, players can no longer manipulate the health bar with their mouse.