### PR TITLE
First round of bugfixes for patch 1

### DIFF
--- a/Dwarf Tarkov/Assets/Plugins/FMOD/platforms/win/lib/x86_64/fmodstudio.dll.meta
+++ b/Dwarf Tarkov/Assets/Plugins/FMOD/platforms/win/lib/x86_64/fmodstudio.dll.meta
@@ -1,74 +1,109 @@
 fileFormatVersion: 2
 guid: 684d4d47a018ed14080e15f4c99b8e86
 PluginImporter:
-  serializedVersion: 1
+  externalObjects: {}
+  serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
-    Android:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    Any:
-      enabled: 0
-      settings: {}
-    Editor:
-      enabled: 1
-      settings:
-        CPU: x86_64
-        DefaultValueInitialized: true
-        OS: Windows
-    Linux:
+  - first:
+      : Linux
+    second:
       enabled: 1
       settings:
         CPU: None
-    Linux64:
-      enabled: 1
-      settings:
-        CPU: x86_64
-    LinuxUniversal:
+  - first:
+      : LinuxUniversal
+    second:
       enabled: 1
       settings:
         CPU: AnyCPU
-    OSXIntel:
+  - first:
+      : OSXIntel
+    second:
       enabled: 1
       settings:
         CPU: None
-    OSXIntel64:
+  - first:
+      : OSXIntel64
+    second:
       enabled: 1
       settings:
         CPU: AnyCPU
-    OSXUniversal:
-      enabled: 1
-      settings:
-        CPU: AnyCPU
-    SamsungTV:
+  - first:
+      : SamsungTV
+    second:
       enabled: 0
       settings:
         STV_MODEL: STANDARD_13
-    WP8:
+  - first:
+      : WP8
+    second:
       enabled: 0
       settings:
         CPU: AnyCPU
         DontProcess: False
         PlaceholderPath: 
-    Win:
+  - first:
+      Android: Android
+    second:
       enabled: 0
       settings:
-        CPU: None
-    Win64:
+        CPU: AnyCPU
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Linux64
+    second:
       enabled: 1
       settings:
         CPU: AnyCPU
-    WindowsStoreApps:
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
       enabled: 0
       settings:
         CPU: AnyCPU
         DontProcess: False
         PlaceholderPath: 
         SDK: AnySDK
-    iOS:
+  - first:
+      iPhone: iOS
+    second:
       enabled: 0
       settings:
         CompileFlags: 

--- a/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
+++ b/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
@@ -330,7 +330,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 7164038243177157252}
   m_HandleRect: {fileID: 0}

--- a/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
+++ b/Dwarf Tarkov/Assets/Project/Prefabs/Player.prefab
@@ -813,8 +813,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 630895194f35ff94b8f6d7dd5d7733f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  movementSpeed: 10
-  sprintSpeed: 7
+  movementSpeed: 7
+  sprintSpeed: 11
 --- !u!61 &4066289266865289181
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Dwarf Tarkov/Assets/Project/Prefabs/UI/Bartering Slot.prefab
+++ b/Dwarf Tarkov/Assets/Project/Prefabs/UI/Bartering Slot.prefab
@@ -34,7 +34,6 @@ RectTransform:
   m_Children:
   - {fileID: 8177549192694916623}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -179,7 +178,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3066516609982016987}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Dwarf Tarkov/Assets/Project/Scenes/Outpost.unity
+++ b/Dwarf Tarkov/Assets/Project/Scenes/Outpost.unity
@@ -5176,6 +5176,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 465d5a1bc62f29949ab1b4893ce96df2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enableLogging: 0
   slot: {fileID: 5147771961530239582, guid: dba9030bb1b74eb4786840d9e71a67f5, type: 3}
   UI: {fileID: 1578586554}
 --- !u!114 &430407609
@@ -7557,6 +7558,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1279571924, guid: e994e0e712a2c69429b0af734df372b8, type: 3}
+      propertyPath: m_Interactable
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1965555291970818275, guid: e994e0e712a2c69429b0af734df372b8,
         type: 3}
       propertyPath: primaryWeapon
@@ -7633,6 +7638,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9096302989177468593, guid: e994e0e712a2c69429b0af734df372b8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Dwarf Tarkov/Assets/Project/Scripts/Bartering/SellboxHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Bartering/SellboxHandler.cs
@@ -115,6 +115,7 @@ public class SellboxHandler : MonoBehaviour
             slots[i].GetComponent<SellboxSlotHandler>().ClearSlot();
         }
         valueText.text = $"Value: 0 credits";
+        value = 0;
         EventChannels.UIEvents.OnCloseBarteringMenu?.Invoke();
     }
 

--- a/Dwarf Tarkov/Assets/Project/Scripts/Bartering/ShopkeepInventory.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Bartering/ShopkeepInventory.cs
@@ -1,5 +1,4 @@
 using EventSystem;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -9,6 +8,17 @@ public class ShopkeepInventory : MonoBehaviour
     private List<ShopKeepItem> inventory = new List<ShopKeepItem>();
     [HideInInspector]
     public List<ShopKeepItem> unlockedItems = new List<ShopKeepItem>();
+
+    private void Awake()
+    {
+        EventChannels.OutpostEvents.OnGetShopInventory += GetShopInventory;
+    }
+
+    private ShopkeepInventory GetShopInventory()
+    {
+        return this;
+    }
+
     // Start is called before the first frame update
     void Start()
     {
@@ -19,6 +29,7 @@ public class ShopkeepInventory : MonoBehaviour
     private void OnDestroy()
     {
         EventChannels.UIEvents.OnPlayerSelectsItemToBuy -= CanBuyItem;
+        EventChannels.OutpostEvents.OnGetShopInventory -= GetShopInventory;
     }
 
     // Update is called once per frame

--- a/Dwarf Tarkov/Assets/Project/Scripts/Bartering/ShopkeepInventory.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Bartering/ShopkeepInventory.cs
@@ -22,8 +22,9 @@ public class ShopkeepInventory : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        EventChannels.UIEvents.OnPlayerSelectsItemToBuy += CanBuyItem;
         UnlockItems();
+        EventChannels.OutpostEvents.OnGetShopInventory += GetShopInventory;
+        EventChannels.UIEvents.OnPlayerSelectsItemToBuy += CanBuyItem;
     }
 
     private void OnDestroy()
@@ -96,10 +97,10 @@ public class ShopkeepInventory : MonoBehaviour
     public void UnlockItems()
     {
         unlockedItems.Clear();
-
+        int playerLevel = (int)EventChannels.PlayerEvents.OnGetPlayerLevel?.Invoke();
         foreach (ShopKeepItem item in inventory)
         {
-            if (EventChannels.PlayerEvents.OnGetPlayerLevel?.Invoke() >= item.UnlockLevel)
+            if ( playerLevel>= item.UnlockLevel)
                 unlockedItems.Add(item);
         }
     }

--- a/Dwarf Tarkov/Assets/Project/Scripts/Debug.meta
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc7b3009596fa0b42afa6c5447e6e826
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dwarf Tarkov/Assets/Project/Scripts/EventSystem/OutpostEvents.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/EventSystem/OutpostEvents.cs
@@ -6,6 +6,7 @@ public class OutpostEvents
 {
     public delegate void ItemEvent(ItemData item, int amount);
     public delegate void OutpostEvent();
+    public delegate ShopkeepInventory ShopInventoryEvent();
 
     public ItemEvent OnAddItemToOutpostInventory;
     public ItemEvent OnRemoveItemFromOutpostInventory;
@@ -17,4 +18,6 @@ public class OutpostEvents
 
     public OutpostEvent OnShowWeaponBench;
     public OutpostEvent OnHideWeaponBench;
+
+    public ShopInventoryEvent OnGetShopInventory;
 }

--- a/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerExperienceHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerExperienceHandler.cs
@@ -13,8 +13,8 @@ public class PlayerExperienceHandler : MonoBehaviour
     [SerializeField]
     [Header("Amount of experience for first level up")]
     private int xpNeededToLevelUp;
-    // Start is called before the first frame update
-    void Start()
+
+    private void Awake()
     {
         SaveData data = EventChannels.DataEvents.OnGetSaveData?.Invoke();
         if (data != null && data.PlayerLevel != 1 && data.PlayerExperience != 0)
@@ -27,6 +27,10 @@ public class PlayerExperienceHandler : MonoBehaviour
             playerLevel = 1;
             experiencePoints = 0;
         }
+    }
+    // Start is called before the first frame update
+    void Start()
+    {
         EventChannels.PlayerEvents.OnExperienceGiven += AddExperience;
         EventChannels.PlayerEvents.OnGetPlayerLevel += GetPlayerLevel;
         EventChannels.DataEvents.OnGetPlayerLevel += GetPlayerLevel;

--- a/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerExperienceHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerExperienceHandler.cs
@@ -27,13 +27,13 @@ public class PlayerExperienceHandler : MonoBehaviour
             playerLevel = 1;
             experiencePoints = 0;
         }
+        EventChannels.PlayerEvents.OnGetPlayerLevel += GetPlayerLevel;
+        EventChannels.DataEvents.OnGetPlayerLevel += GetPlayerLevel;
     }
     // Start is called before the first frame update
     void Start()
     {
         EventChannels.PlayerEvents.OnExperienceGiven += AddExperience;
-        EventChannels.PlayerEvents.OnGetPlayerLevel += GetPlayerLevel;
-        EventChannels.DataEvents.OnGetPlayerLevel += GetPlayerLevel;
         EventChannels.DataEvents.OnGetPlayerExperience += GetExperience;
     }
 

--- a/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerMovementHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/Player/PlayerMovementHandler.cs
@@ -23,6 +23,7 @@ public class PlayerMovementHandler : MonoBehaviour
     private void OnDestroy()
     {
         EventChannels.PlayerInputEvents.OnPlayerMove -= Move;
+        EventChannels.PlayerInputEvents.OnPlayerSprint -= SetIsSprinting;
     }
 
     void SetIsSprinting(bool sprinting)

--- a/Dwarf Tarkov/Assets/Project/Scripts/UI/BarterUI/BarterUIPlayerInventoryManager.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/UI/BarterUI/BarterUIPlayerInventoryManager.cs
@@ -17,7 +17,7 @@ public class BarterUIPlayerInventoryManager : MonoBehaviour
             inventorySlots.Add(slot);
             slot.SetActive(true);
             // really sloppy way to force the inventory to update at the beginning of the game
-            UpdateInventory(new ShopkeepInventory());
+            UpdateInventory(EventChannels.OutpostEvents.OnGetShopInventory?.Invoke());
         }
     }
 
@@ -25,24 +25,22 @@ public class BarterUIPlayerInventoryManager : MonoBehaviour
     {
         EventChannels.UIEvents.OnOpenBarteringMenu -= UpdateInventory;
     }
+
     void UpdateInventory(ShopkeepInventory shop)
     {
         List<Item> items = EventChannels.ItemEvents.OnGetPlayerInventory?.Invoke();
-        if (items.Count > 0)
+        for (int i = 0; i < inventorySlots.Count; i++)
         {
-            for (int i = 0; i < inventorySlots.Count; i++)
+            GameObject slot = inventorySlots[i];
+            if (i < items.Count)
             {
-                GameObject slot = inventorySlots[i];
-                if (i < items.Count)
-                {
-                    Item item = items[i];
-                    slot.GetComponent<PlayerBarterSlotHandler>().SetSlot(item);
-                }
-                else
-                {
-                    // Clear the slot if there is no corresponding item
-                    slot.GetComponent<PlayerBarterSlotHandler>().ClearSlot();
-                }
+                Item item = items[i];
+                slot.GetComponent<PlayerBarterSlotHandler>().SetSlot(item);
+            }
+            else
+            {
+                // Clear the slot if there is no corresponding item
+                slot.GetComponent<PlayerBarterSlotHandler>().ClearSlot();
             }
         }
     }

--- a/Dwarf Tarkov/Assets/Project/Scripts/UI/BarterUI/PlayerBarterSlotHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/UI/BarterUI/PlayerBarterSlotHandler.cs
@@ -22,7 +22,7 @@ public class PlayerBarterSlotHandler : MonoBehaviour
         isTaken = true;
         if (item.data.IsStackable)
         {
-            amountText.enabled = true;
+            amountText.gameObject.SetActive(true);
             amountText.SetText(item.amount.ToString());
         }
     }
@@ -33,7 +33,7 @@ public class PlayerBarterSlotHandler : MonoBehaviour
         image.sprite = null;
         image.enabled = false;
         isTaken = false;
-        amountText.enabled = false;
+        amountText.gameObject.SetActive(false);
     }
 
     public void SellItem()

--- a/Dwarf Tarkov/Assets/Project/Scripts/UI/Weapon Bench/LoadoutSlotHandler.cs
+++ b/Dwarf Tarkov/Assets/Project/Scripts/UI/Weapon Bench/LoadoutSlotHandler.cs
@@ -33,6 +33,8 @@ public class LoadoutSlotHandler : MonoBehaviour
 
     void SetWeapon(WeaponData data)
     {
+        if (data == null)
+            return;
         this.data = data;
         SetSprite(data.Sprite);
     }

--- a/Dwarf Tarkov/ProjectSettings/ProjectSettings.asset
+++ b/Dwarf Tarkov/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,8 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1.0
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: b54f66296840fe54db0a22fad54d6c7c, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/Dwarf Tarkov/ProjectSettings/ProjectSettings.asset
+++ b/Dwarf Tarkov/ProjectSettings/ProjectSettings.asset
@@ -140,8 +140,7 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1.0
-  preloadedAssets:
-  - {fileID: 11400000, guid: b54f66296840fe54db0a22fad54d6c7c, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
-Fixed a bug where player would not sprint while holding the sprint key
-Fixed a number displaying on empty inventory slots in the buy menu
-Fixed a bug where the value of sold items would remain cached, allowing the player to infinitely stack credits
-Fixed the health bar being interactable, players can no longer manipulate the health bar with their mouse.
-Fixed the shopkeeper's inventory not showing up